### PR TITLE
Fix tool path for Espressif32 frameworks 4.X and 5.X

### DIFF
--- a/download_fs.py
+++ b/download_fs.py
@@ -48,7 +48,12 @@ class LittleFSInfo(FSInfo):
     def __init__(self, start, length, page_size, block_size):
         if env["PIOPLATFORM"] == "espressif32":
             #for ESP32: retrieve and evaluate, e.g. to mkspiffs_espressif32_arduino
-            self.tool = env.subst(env["MKSPIFFSTOOL"])
+            #Espressif32 Framework 3.X.X: MKSPIFFSTOOL
+            #Espressif32 Framework 4.X.X and 5.X.X: MKFSTOOL
+            if "MKSPIFFSTOOL" in env:
+                self.tool = env.subst(env["MKSPIFFSTOOL"])
+            else:
+                self.tool = env.subst(env["MKFSTOOL"])
         else:
             self.tool = env["MKFSTOOL"] # from mkspiffs package
         self.tool = join(platform.get_package_dir("tool-mklittlefs"), self.tool)
@@ -63,7 +68,12 @@ class SPIFFSInfo(FSInfo):
     def __init__(self, start, length, page_size, block_size):
         if env["PIOPLATFORM"] == "espressif32":
             #for ESP32: retrieve and evaluate, e.g. to mkspiffs_espressif32_arduino
-            self.tool = env.subst(env["MKSPIFFSTOOL"])
+            #Espressif32 Framework 3.X.X: MKSPIFFSTOOL
+            #Espressif32 Framework 4.X.X and 5.X.X: MKFSTOOL
+            if "MKSPIFFSTOOL" in env:
+                self.tool = env.subst(env["MKSPIFFSTOOL"])
+            else:
+                self.tool = env.subst(env["MKFSTOOL"])
         else:
             self.tool = env["MKFSTOOL"] # from mkspiffs package
         self.tool = join(platform.get_package_dir("tool-mkspiffs"), self.tool)


### PR DESCRIPTION
The environment variable for the tool-mkspiffs changed on recent platform updates
With all 3.X versions it was saved under the MKSPIFFSTOOL key
For 4.X and 5.X versions it can now be found with the MKFSTOOL key